### PR TITLE
Fixed to have correct log message / Test cases for different handler situations

### DIFF
--- a/examples/handlers-tests/Main.hs
+++ b/examples/handlers-tests/Main.hs
@@ -6,6 +6,10 @@
 
  Example of @plutarch-quickcheck@ tests. These are meant to be read as source
  code.
+
+ handlers-tests contains cases corresponding to each possible outputs of `classifiedProperty`.
+ It demonstrates how each conditions of `classifiedProperty` is evoked, and also serves as a test
+ to check if `classifiedProperty` is working correctly.
 -}
 module Main (main) where
 

--- a/examples/handlers-tests/Main.hs
+++ b/examples/handlers-tests/Main.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE TypeApplications #-}
+
+{- | Module: Main
+ Copyright: (C) Liqwid Labs 2022
+ License: Apache 2.0
+ Portability: GHC only
+ Stability: Experimental
+
+ Example of @plutarch-quickcheck@ tests. These are meant to be read as source
+ code.
+-}
+module Main (main) where
+
+import Data.Tagged (Tagged (Tagged))
+import Data.Universe (Finite (cardinality, universeF), Universe (universe))
+import Plutarch
+import Plutarch.Integer (PInteger, pquot)
+import Plutarch.Maybe
+--import Plutarch.TermCont
+--import Plutarch.Trace
+
+import Test.QuickCheck
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.Plutarch.Property (classifiedProperty)
+import Test.Tasty.QuickCheck (testProperty)
+
+data HandlerCases = EvenNumber | OddNumber
+    deriving stock (Eq, Show)
+
+instance Universe HandlerCases where
+    universe = [EvenNumber, OddNumber]
+
+instance Finite HandlerCases where
+    universeF = universe
+    cardinality = Tagged 2
+
+classifier :: Integer -> HandlerCases
+classifier a
+  | even a = EvenNumber
+  | otherwise = OddNumber
+
+generator :: HandlerCases -> Gen Integer
+generator EvenNumber = (arbitrary :: Gen Integer) >>= (\number -> return $ number * 2)
+generator OddNumber = (arbitrary :: Gen Integer) >>= (\number -> return $ number * 2 + 1)
+  
+shrinker :: Integer -> [Integer]
+shrinker = shrink
+
+expected :: forall (s :: S). Term s ( PInteger :--> PMaybe PInteger)
+expected = phoistAcyclic $
+  plam $ \_t -> unTermCont $ do
+    pure $ pcon $ PNothing
+
+definition :: forall (s :: S). Term s (PInteger :--> PInteger)
+definition = pquot # 2 
+
+ourProperty :: Property
+ourProperty = classifiedProperty generator shrinker expected classifier definition
+
+main :: IO ()
+main = do
+    defaultMain . testGroup "Handlers" $
+        [ testProperty "will Fail" ourProperty
+        ]

--- a/plutarch-quickcheck.cabal
+++ b/plutarch-quickcheck.cabal
@@ -75,6 +75,7 @@ common common-tests
     , QuickCheck
     , tagged
     , tasty
+    , tasty-expected-failure
     , tasty-quickcheck
     , universe
 

--- a/plutarch-quickcheck.cabal
+++ b/plutarch-quickcheck.cabal
@@ -122,3 +122,9 @@ test-suite natural-tests
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
   hs-source-dirs: examples/natural-tests
+
+test-suite handlers-tests
+  import:         common-tests
+  type:           exitcode-stdio-1.0
+  main-is:        Main.hs
+  hs-source-dirs: examples/handlers-tests


### PR DESCRIPTION
- Fixed #5, it presents correct log message when property is expected to fail but script succeeds
Issue was the use of negative number; negative number made an incorrect comparison. Check added comment for more information.

- Added `handlers-tests` that checks all possible outputs of `classifiedProperty`. Check the following result. 
```
Possible outputs of classifiedProperty
  "expected: Failure/yields: Success":               FAIL (expected: expects failure but script runs successfully)
    *** Failed! Falsified (after 3 tests and 2 shrinks):
    Generated input 2
    No logs found.
    Did you forget to build Plutarch with +development?
    A case which should have crashed ran successfully instead.
    Use --quickcheck-replay=475499 to reproduce. (expected failure)
  "expected: Failure/yields: Failure":               OK (0.16s)
    +++ OK, passed 6400 tests:
    50.31% OddNumber
    49.69% EvenNumber
  "expected: Success/yields: Failure":               FAIL (expected: expects success but script crashed)
    *** Failed! Falsified (after 1 test):
    Generated input 0
    No logs found.
    Did you forget to build Plutarch with +development?
    Expected a successful run, but crashed instead.
    Error details
                                                        An error has occurred:  User error:
    The provided Plutus code called 'error'.
    Use --quickcheck-replay=606309 to reproduce. (expected failure)
  "expected: Success/yields: Success but Incorrect": FAIL (expected: Yielded value is incorrect)
    *** Failed! Falsified (after 1 test):
    Generated input 1
    No logs found.
    Did you forget to build Plutarch with +development?
    Test script result does not match expected value.
    Use --quickcheck-replay=808582 to reproduce. (expected failure)
  "expected: Success/yields: Success and Correct":   OK (0.13s)
    +++ OK, passed 6400 tests:
    51.09% EvenNumber
    48.91% OddNumber

All 5 tests passed (0.16s)
```