### PR TITLE
AlwaysFail property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,15 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 ### Added
 
 * First release
+
+## 1.0.1 -- 2022-05-17
+
+### Added
+
+* `alwaysFailProperty` -- an universial property that ensures script always fails
+
+### Fixed
+
+* Bug that made `classifiedProperty` fail to differentiate between
+  wrong result and expected crash when script ran without
+  crashing. (Fixed #5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
-## 1.0.0 -- 2022-05-05
-
-### Added
-
-* First release
-
 ## 1.0.1 -- 2022-05-17
 
 ### Added
@@ -19,3 +13,9 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 * Bug that made `classifiedProperty` fail to differentiate between
   wrong result and expected crash when script ran without
   crashing. (Fixed #5)
+
+## 1.0.0 -- 2022-05-05
+
+### Added
+
+* First release

--- a/examples/handlers-tests/Main.hs
+++ b/examples/handlers-tests/Main.hs
@@ -102,13 +102,13 @@ expectedSuccessCorrectValue = classifiedProperty generator shrinker expected cla
     definition = plam id
 
 alwaysFails :: Property
-alwaysFails = alwaysFailProperty generator shrinker classifier definition
+alwaysFails = alwaysFailProperty arbitrary shrink definition
   where
     definition :: forall (s :: S). Term s (PInteger :--> PInteger)
     definition = plam $ const $ ptraceError "failed"
 
 alwaysFailsSucceeds :: Property
-alwaysFailsSucceeds = alwaysFailProperty generator shrinker classifier definition
+alwaysFailsSucceeds = alwaysFailProperty arbitrary shrink definition
   where
     definition :: forall (s :: S). Term s (PInteger :--> PInteger)
     definition = plam $ const $ 5
@@ -147,4 +147,4 @@ main = do
             ]
   where
     go :: QuickCheckTests -> QuickCheckTests
-    go = max 10000000
+    go = max 10000

--- a/examples/handlers-tests/Main.hs
+++ b/examples/handlers-tests/Main.hs
@@ -29,10 +29,10 @@ import Test.QuickCheck (
     Gen,
     Property,
  )
-import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty (adjustOption, defaultMain, testGroup)
 import Test.Tasty.ExpectedFailure (expectFailBecause)
-import Test.Tasty.Plutarch.Property (classifiedProperty)
-import Test.Tasty.QuickCheck (testProperty)
+import Test.Tasty.Plutarch.Property (alwaysFailProperty, classifiedProperty)
+import Test.Tasty.QuickCheck (QuickCheckTests, testProperty)
 
 data HandlerCases = EvenNumber | OddNumber
     deriving stock (Eq, Show)
@@ -101,15 +101,50 @@ expectedSuccessCorrectValue = classifiedProperty generator shrinker expected cla
     definition :: forall (s :: S). Term s (PInteger :--> PInteger)
     definition = plam id
 
+alwaysFails :: Property
+alwaysFails = alwaysFailProperty generator shrinker classifier definition
+  where
+    definition :: forall (s :: S). Term s (PInteger :--> PInteger)
+    definition = plam $ const $ ptraceError "failed"
+
+alwaysFailsSucceeds :: Property
+alwaysFailsSucceeds = alwaysFailProperty generator shrinker classifier definition
+  where
+    definition :: forall (s :: S). Term s (PInteger :--> PInteger)
+    definition = plam $ const $ 5
+
+alwaysFailsOnClassifiedProperty :: Property
+alwaysFailsOnClassifiedProperty = classifiedProperty generator shrinker expected classifier definition
+  where
+    expected :: forall (s :: S). Term s (PInteger :--> PMaybe PInteger)
+    expected = plam $ const $ pcon $ PNothing
+
+    definition :: forall (s :: S). Term s (PInteger :--> PInteger)
+    definition = plam $ const $ ptraceError "failed"
+
 main :: IO ()
 main = do
-    defaultMain . testGroup "Possible outputs of classifiedProperty" $
-        [ expectFailBecause "expects failure but script runs successfully" $
-            testProperty "\"expected: Failure/yields: Success\"" expectedFailureSucceeding
-        , testProperty "\"expected: Failure/yields: Failure\"" expectedFailureFailing
-        , expectFailBecause "expects success but script crashed" $
-            testProperty "\"expected: Success/yields: Failure\"" expectedSuccessFailing
-        , expectFailBecause "Yielded value is incorrect" $
-            testProperty "\"expected: Success/yields: Success but Incorrect\"" expectedSuccessIncorrectValue
-        , testProperty "\"expected: Success/yields: Success and Correct\"" expectedSuccessCorrectValue
-        ]
+    defaultMain $
+        testGroup
+            "Handlers Tests"
+            [ testGroup "Possible outputs of classifiedProperty" $
+                [ expectFailBecause "expects failure but script runs successfully" $
+                    testProperty "\"expected: Failure/yields: Success\"" expectedFailureSucceeding
+                , testProperty "\"expected: Failure/yields: Failure\"" expectedFailureFailing
+                , expectFailBecause "expects success but script crashed" $
+                    testProperty "\"expected: Success/yields: Failure\"" expectedSuccessFailing
+                , expectFailBecause "Yielded value is incorrect" $
+                    testProperty "\"expected: Success/yields: Success but Incorrect\"" expectedSuccessIncorrectValue
+                , testProperty "\"expected: Success/yields: Success and Correct\"" expectedSuccessCorrectValue
+                ]
+            , adjustOption go $
+                testGroup "alwaysFailproperty" $
+                    [ expectFailBecause "expects failure but script runs successfully" $
+                        testProperty "\"expected: Failure/yields: Success\"" alwaysFailsSucceeds
+                    , testProperty "faster (using alwaysFailProperty)" alwaysFails
+                    , testProperty "slower (using classifiedProperty)" alwaysFailsOnClassifiedProperty
+                    ]
+            ]
+  where
+    go :: QuickCheckTests -> QuickCheckTests
+    go = max 10000000

--- a/src/Test/Tasty/Plutarch/Property.hs
+++ b/src/Test/Tasty/Plutarch/Property.hs
@@ -208,7 +208,6 @@ alwaysFailProperty ::
     , Show ix
     , PLifted c ~ a
     , PUnsafeLiftDecl c
-    , PEq d
     ) =>
     -- | A way to generate values for each case. We expect that for any such
     -- generated value, the classification function should report the appropriate
@@ -224,10 +223,10 @@ alwaysFailProperty ::
 alwaysFailProperty getGen shr classify comp = case cardinality @ix of
     Tagged 0 -> failOutNoCases
     Tagged 1 -> failOutOneCase
-    _ -> forAllShrinkShow gen shr' (showInput . snd) (go (classifiedTemplate comp expectFailure))
+    _ -> forAllShrinkShow gen shr' (showInput . snd) (go comp)
   where
-    expectFailure :: forall (s :: S). Term s (c :--> PMaybe d)
-    expectFailure = phoistAcyclic $ plam $ const $ pcon PNothing
+    -- expectFailure :: forall (s :: S). Term s (c :--> PMaybe d)
+    -- expectFailure = phoistAcyclic $ plam $ const $ pcon PNothing
     gen :: Gen (ix, a)
     gen = do
         ix <- elements universeF
@@ -238,7 +237,7 @@ alwaysFailProperty getGen shr classify comp = case cardinality @ix of
         guard (classify x' == ix)
         pure (ix, x')
     go ::
-        (forall (s' :: S). Term s' (c :--> PInteger)) ->
+        (forall (s' :: S). Term s' (c :--> d)) ->
         (ix, a) ->
         Property
     go precompiled (ix, input) =

--- a/src/Test/Tasty/Plutarch/Property.hs
+++ b/src/Test/Tasty/Plutarch/Property.hs
@@ -107,8 +107,7 @@ peqProperty expected gen shr comp =
 
 {- | 'alwaysFailProperty' universally checks if given computation fails.
  This runs the given script with generated input; it makes sure that
- script fails by crashes or errors.  Since output does not need to be
- checked, `PEq` instance is not required.
+ script fails by crashes or errors.
 
  This function provides quicker and simpler interface when writing
  properties involving, for example, a validator or a minting policy

--- a/src/Test/Tasty/Plutarch/Property.hs
+++ b/src/Test/Tasty/Plutarch/Property.hs
@@ -131,11 +131,11 @@ alwaysFailProperty gen shr comp = forAllShrinkShow gen shr showInput (go comp)
         a ->
         Property
     go precompiled input =
-      let s = compile (precompiled # pconstant input)
-          (res, _, _) = evalScript s
-      in case res of
-             Right _ -> counterexample ranOnCrash . property $ False
-             Left _ -> property True
+        let s = compile (precompiled # pconstant input)
+            (res, _, _) = evalScript s
+         in case res of
+                Right _ -> counterexample ranOnCrash . property $ False
+                Left _ -> property True
 
 {- | Given a finite set of classes, each with an associated generator of inputs,
  a shrinker for inputs, a Plutarch function for constructing (possible)

--- a/src/Test/Tasty/Plutarch/Property.hs
+++ b/src/Test/Tasty/Plutarch/Property.hs
@@ -225,8 +225,6 @@ alwaysFailProperty getGen shr classify comp = case cardinality @ix of
     Tagged 1 -> failOutOneCase
     _ -> forAllShrinkShow gen shr' (showInput . snd) (go comp)
   where
-    -- expectFailure :: forall (s :: S). Term s (c :--> PMaybe d)
-    -- expectFailure = phoistAcyclic $ plam $ const $ pcon PNothing
     gen :: Gen (ix, a)
     gen = do
         ix <- elements universeF
@@ -240,18 +238,18 @@ alwaysFailProperty getGen shr classify comp = case cardinality @ix of
         (forall (s' :: S). Term s' (c :--> d)) ->
         (ix, a) ->
         Property
-    go precompiled (ix, input) =
-        let classified = classify input
-         in if ix /= classified
-                then failedClassification ix classified
-                else
-                    let s = compile (precompiled # pconstant input)
-                        (res, _, logs) = evalScript s
-                     in counterexample (prettyLogs logs)
-                            . ensureCovered input classify
-                            $ case res of
-                                Right _ -> counterexample ranOnCrash . property $ False
-                                Left _ -> property True
+    go precompiled (ix, input)
+        | ix /= classified = failedClassification ix classified
+        | otherwise =
+            let s = compile (precompiled # pconstant input)
+                (res, _, logs) = evalScript s
+             in counterexample (prettyLogs logs)
+                    . ensureCovered input classify
+                    $ case res of
+                        Right _ -> counterexample ranOnCrash . property $ False
+                        Left _ -> property True
+      where
+        classified = classify input
 
 -- Note from Koz
 --


### PR DESCRIPTION
```
    faster (using alwaysFailProperty):                 OK (0.23s)
      +++ OK, passed 6400 tests:
      50.30% EvenNumber
      49.70% OddNumber
    slower (using classifiedProperty):                 OK (0.27s)
      +++ OK, passed 6400 tests:
      50.77% EvenNumber
      49.23% OddNumber
```

Noticeable performance boost as `alwaysFailProperty` will only run script once when it is expected to crash.  

Should close #6 