### PR TITLE
Plutus v2 migration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2731,11 +2731,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1659383708,
-        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "lastModified": 1659565263,
+        "narHash": "sha256-jX2b2qvyHAG701fZmsTC2lB78ffuDmTOYU01KxTrdXI=",
         "owner": "Liqwid-Labs",
         "repo": "liqwid-nix",
-        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "rev": "5a4d46604a335cf39bffc7f349fc71bbaae1ce2a",
         "type": "github"
       },
       "original": {
@@ -3586,16 +3586,32 @@
     },
     "nixpkgs-2111_9": {
       "locked": {
-        "lastModified": 1659375853,
-        "narHash": "sha256-aiMfO6U1w1u93vB+5qCHCQDZKgpJ7qs4GJOQvI3CN/4=",
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "511f6a5c3248f9019a41e70c1891484de2bc906c",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1653936696,
+        "narHash": "sha256-M6bJShji9AIDZ7Kh7CPwPBPb/T7RiVev2PAcOi4fxDQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ce6aa13369b667ac2542593170993504932eb836",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "22.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -3778,17 +3794,17 @@
     },
     "nixpkgs-latest_9": {
       "locked": {
-        "lastModified": 1653918805,
-        "narHash": "sha256-6ahwAnBNGgqSNSn/6RnsxrlFi+fkA+RyT6o/5S1915o=",
+        "lastModified": 1659622790,
+        "narHash": "sha256-fYelfx2ScXVprcivGPif+hi9cOZPt3/4wV5rC3AwZDs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
+        "rev": "cf63df0364f67848083ff75bc8ac9b7ca7aa5a01",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
+        "rev": "cf63df0364f67848083ff75bc8ac9b7ca7aa5a01",
         "type": "github"
       }
     },
@@ -5276,6 +5292,7 @@
           "nixpkgs"
         ],
         "nixpkgs-2111": "nixpkgs-2111_9",
+        "nixpkgs-2205": "nixpkgs-2205",
         "nixpkgs-latest": "nixpkgs-latest_9",
         "plutarch": "plutarch_5",
         "plutarch-numeric": "plutarch-numeric_2"

--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,12 @@
 
   inputs = {
     nixpkgs.follows = "plutarch/nixpkgs";
-    nixpkgs-latest.url = "github:NixOS/nixpkgs?rev=a0a69be4b5ee63f1b5e75887a406e9194012b492";
+    nixpkgs-latest.url = "github:NixOS/nixpkgs?rev=cf63df0364f67848083ff75bc8ac9b7ca7aa5a01";
 
     # temporary fix for nix versions that have the transitive follows bug
     # see https://github.com/NixOS/nix/issues/6013
     nixpkgs-2111 = { url = "github:NixOS/nixpkgs/nixpkgs-21.11-darwin"; };
+    nixpkgs-2205 = { url = "github:NixOS/nixpkgs/22.05"; };
 
     haskell-nix-extra-hackage.follows = "plutarch/haskell-nix-extra-hackage";
     haskell-nix.follows = "plutarch/haskell-nix";

--- a/plutarch-quickcheck.cabal
+++ b/plutarch-quickcheck.cabal
@@ -72,8 +72,8 @@ library
     , containers
     , data-default
     , generics-sop
-    , liqwid-plutarch-extra
     , mtl
+    , plutarch-extra
     , plutus-core
     , plutus-ledger-api
     , plutus-tx

--- a/src/Plutarch/Test/QuickCheck/Function.hs
+++ b/src/Plutarch/Test/QuickCheck/Function.hs
@@ -21,10 +21,9 @@ import Data.Kind (Type)
 import Data.List (intercalate, nubBy)
 import Data.Universe (Finite (universeF))
 import Plutarch (S, Term, plam, (#), (#$), type (:-->))
-import "liqwid-plutarch-extra" Plutarch.Extra.List (plookup)
-import Plutarch.Extra.Maybe (pfromJust, pmaybe)
 import Plutarch.Lift (PLift, PUnsafeLiftDecl (PLifted), pconstant)
-import Plutarch.Prelude (PBuiltinList, PBuiltinPair, PEq)
+import Plutarch.Maybe (pfromJust)
+import Plutarch.Prelude (PBool, PBuiltinList, PBuiltinPair, PEq, PIsListLike, PMaybe (PJust, PNothing), pcon, pfstBuiltin, phoistAcyclic, pif, pmatch, precList, psndBuiltin, (#==))
 import Plutarch.Test.QuickCheck.Instances (TestableTerm (TestableTerm, unTestableTerm))
 import Test.QuickCheck (
     Arbitrary (arbitrary, shrink),
@@ -136,3 +135,40 @@ plamFinite f = plam $ \x -> pfromJust #$ plookup # x # table
   where
     table :: Term s (PBuiltinList (PBuiltinPair a b))
     table = pconstant $ (id &&& f) <$> universeF
+
+--------------------------------------------------------------------------------
+-- The following functions are copies of the versions present in
+-- `liqwid-plutarch-extra`, and are inserted here to avoid cyclic dependency
+-- issues
+
+-- | Extract a 'PMaybe' by providing a default value in case of 'PJust'.
+pmaybe ::
+    forall (a :: S -> Type) (s :: S).
+    Term s (a :--> PMaybe a :--> a)
+pmaybe = phoistAcyclic $
+    plam $ \e a -> pmatch a $ \case
+        PJust a' -> a'
+        PNothing -> e
+
+-- | /O(n)/. Find the value for a given key in an associative list.
+plookup ::
+    forall (a :: S -> Type) (b :: S -> Type) (s :: S) list.
+    (PEq a, PIsListLike list (PBuiltinPair a b)) =>
+    Term s (a :--> list (PBuiltinPair a b) :--> PMaybe b)
+plookup =
+    phoistAcyclic $
+        plam $ \k xs ->
+            pmatch (pfind' (\p -> pfstBuiltin # p #== k) # xs) $ \case
+                PNothing -> pcon PNothing
+                PJust p -> pcon (PJust (psndBuiltin # p))
+
+-- | Get the first element that matches a predicate or return Nothing.
+pfind' ::
+    forall (a :: S -> Type) (s :: S) list.
+    PIsListLike list a =>
+    (Term s a -> Term s PBool) ->
+    Term s (list a :--> PMaybe a)
+pfind' p =
+    precList
+        (\self x xs -> pif (p x) (pcon (PJust x)) (self # xs))
+        (const $ pcon PNothing)

--- a/src/Plutarch/Test/QuickCheck/Instances.hs
+++ b/src/Plutarch/Test/QuickCheck/Instances.hs
@@ -4,9 +4,7 @@
 {-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE QuantifiedConstraints #-}
-
 {-# LANGUAGE TypeApplications #-}
-
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -215,7 +213,7 @@ instance PShow a => Show (TestableTerm a) where
 class PArbitrary (a :: S -> Type) where
     parbitrary :: Gen (TestableTerm a)
     default parbitrary :: (PLift a, Arbitrary (PLifted a)) => Gen (TestableTerm a)
-    parbitrary =  pconstantT <$> arbitrary
+    parbitrary = pconstantT <$> arbitrary
 
     pshrink :: TestableTerm a -> [TestableTerm a]
     pshrink = const []

--- a/src/Plutarch/Test/QuickCheck/Instances.hs
+++ b/src/Plutarch/Test/QuickCheck/Instances.hs
@@ -34,20 +34,14 @@ import Plutarch (
     (#$),
  )
 import Plutarch.Api.V1 (
-    AmountGuarantees (NoGuarantees, NonZero, Positive),
-    KeyGuarantees (Sorted, Unsorted),
-    PAddress (PAddress),
+    AmountGuarantees (NonZero),
     PCredential (PPubKeyCredential, PScriptCredential),
     PCurrencySymbol (PCurrencySymbol),
     PExtended (PFinite, PNegInf, PPosInf),
     PInterval (PInterval),
     PLowerBound (PLowerBound),
     PMap (PMap),
-    PMaybeData (PDJust, PDNothing),
-    PPOSIXTime,
-    PPubKeyHash (PPubKeyHash),
     PStakeValidatorHash (PStakeValidatorHash),
-    PStakingCredential (PStakingHash, PStakingPtr),
     PTokenName (PTokenName),
     PUpperBound (PUpperBound),
     PValidatorHash (PValidatorHash),
@@ -66,6 +60,14 @@ import Plutarch.Api.V1.Tuple (
  )
 import qualified "plutarch" Plutarch.Api.V1.Value as Value (
     pnormalize,
+ )
+import Plutarch.Api.V2 (
+    AmountGuarantees (NoGuarantees, Positive),
+    KeyGuarantees (Sorted, Unsorted),
+    PAddress (PAddress),
+    PMaybeData (PDJust, PDNothing),
+    PPubKeyHash (PPubKeyHash),
+    PStakingCredential (PStakingHash, PStakingPtr),
  )
 import Plutarch.Evaluate (evalScript)
 import Plutarch.Extra.Map.Unsorted (psort)

--- a/src/Plutarch/Test/QuickCheck/Instances.hs
+++ b/src/Plutarch/Test/QuickCheck/Instances.hs
@@ -215,7 +215,7 @@ instance PShow a => Show (TestableTerm a) where
 class PArbitrary (a :: S -> Type) where
     parbitrary :: Gen (TestableTerm a)
     default parbitrary :: (PLift a, Arbitrary (PLifted a)) => Gen (TestableTerm a)
-    parbitrary = (TestableTerm . pconstant) <$> arbitrary
+    parbitrary =  pconstantT <$> arbitrary
 
     pshrink :: TestableTerm a -> [TestableTerm a]
     pshrink = const []


### PR DESCRIPTION
Upgraded to the V2 API types. 

Some things to note: 

-----

The following types don't seem to be re-exported by `Plutarch.Api.V2`: 

- PValue
- psingletonValue
- PCurrencySymbol
- PTokenName
- PAmountGuarantees (NonZero)
- PStakeValidatorHash
- all of Plutarch.Api.V1.AssocMap?
- pnormalize
- `pbuiltinPairFromTuple`
- `ptuple`
- `ptupleFromBuiltin`
- PCredential
- PPOSIXTime (PPOSIXTime) -- data constructor not exported in Plutarch.Api.V1 either; is this deliberate?
- PExtended
- PInterval
- PLowerBound
- PUpperBound
- PValidatorHash

I'm not sure if this is on purpose or not, but I'll be asking on the plutarch channel shortly.

-------

There was a somewhat substantial dependency on LPE that needed to be removed in order to make things compile. I've inlined all the necessary functions, but there's probably a better way. I'm happy to revise this PR if there's a better solution we'd like to pursue.