### PR TITLE
Be positive

### DIFF
--- a/src/Plutarch/Test/QuickCheck/Instances.hs
+++ b/src/Plutarch/Test/QuickCheck/Instances.hs
@@ -279,7 +279,7 @@ instance PCoArbitrary PByteString where
 instance PArbitrary PPositive where
     parbitrary = do
         (TestableTerm x) <- parbitrary
-        return $ TestableTerm $ ptryPositive #$ pif (0 #< x) x (negate (x + 1))
+        return $ TestableTerm $ ptryPositive #$ pif (0 #< x) x (negate x + 1)
 
 -- | @since 2.0.0
 instance PCoArbitrary PPositive where


### PR DESCRIPTION
Fix this:
```
ghci> defaultMain $ testProperty "test this: " $ fromPFun $ plam $ \(r :: Term s PPositive) -> r #== r
test this: : FAIL
  *** Failed! (after 1 test):
  Exception:
    plift failed: erring term: An error has occurred:  User error:
    The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
    CallStack (from HasCallStack):
      error, called at ./Plutarch/Lift.hs:133:35 in plutarch-1.2.0-Az3vxjh9qFD1Kam6ZOeUZM:Plutarch.Lift
      plift, called at src/Plutarch/Test/QuickCheck/Instances.hs:135:43 in plutarch-quickcheck-2.0.0-1QVzYHXovsR1LL0FscNocF:Plutarch.Test.QuickCheck.Instances
  ptryPositive: building with non positive
  Use --quickcheck-replay=948910 to reproduce.

1 out of 1 tests failed (0.01s)
*** Exception: ExitFailure 1
```