### PR TITLE
Arbitrary instance for `PDataRecord` and `PDataSum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 2.1.1 -- 2022-09-11
+
+### Added
+
+* `PArbitrary` instances for `PDataRecord` and `PDataSum`.
+
 ## 2.1.0 -- 2022-09-01
 
 ### Added

--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
         "secp256k1-haskell": "secp256k1-haskell"
       },
       "locked": {
-        "lastModified": 1660577072,
-        "narHash": "sha256-FGx86CLJbkzHnhkTHKb4P37WZmPIJuO/0PjvK6VMnrE=",
+        "lastModified": 1662289207,
+        "narHash": "sha256-qEQQrLB87zIvQ/jjNsTSaowLDYxVyrry40u07148ikQ=",
         "owner": "Plutonomicon",
         "repo": "plutarch-plutus",
-        "rev": "79127ad4379828c525200f5e5173894246fa6566",
+        "rev": "a9141ad6dc6ae3aae0697a4ddcb490f3ada1563d",
         "type": "github"
       },
       "original": {

--- a/src/Plutarch/Test/QuickCheck/Helpers.hs
+++ b/src/Plutarch/Test/QuickCheck/Helpers.hs
@@ -16,4 +16,4 @@ scriptBudget :: ClosedTerm p -> String
 scriptBudget x =
   case evalTerm (Config {tracingMode = NoTracing}) x of
     Right (_, b, _) -> show b
-    Left err -> error $ show err    
+    Left err -> error $ show err

--- a/src/Plutarch/Test/QuickCheck/Helpers.hs
+++ b/src/Plutarch/Test/QuickCheck/Helpers.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE RankNTypes #-}
 
-module Plutarch.Test.QuickCheck.Helpers (loudEval) where
+module Plutarch.Test.QuickCheck.Helpers (loudEval, scriptBudget) where
 
-import Plutarch (ClosedTerm, Config (..), TracingMode (DoTracing))
+import Plutarch (ClosedTerm, Config (..), TracingMode (DoTracing, NoTracing))
 import Plutarch.Evaluate (evalTerm)
 
 loudEval :: ClosedTerm p -> ClosedTerm p
@@ -11,3 +11,9 @@ loudEval x =
     Right (Right t, _, _) -> t
     Right (Left err, _, trace) -> error $ show err <> show trace -- TODO pretty this output
     Left err -> error $ show err
+
+scriptBudget :: ClosedTerm p -> String
+scriptBudget x =
+  case evalTerm (Config {tracingMode = NoTracing}) x of
+    Right (_, b, _) -> show b
+    Left err -> error $ show err    

--- a/src/Plutarch/Test/QuickCheck/Instances.hs
+++ b/src/Plutarch/Test/QuickCheck/Instances.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE GADTs #-}

--- a/src/Plutarch/Test/QuickCheck/Instances.hs
+++ b/src/Plutarch/Test/QuickCheck/Instances.hs
@@ -245,7 +245,7 @@ instance
     return $ TestableTerm $ pdcons # pdata x # xs
   pshrink xs =
     [ TestableTerm $ pdcons # x' # xs'
-    | (TestableTerm x') <- shrink (pdhead xs)
+    | (TestableTerm x') <- idIfEmpty (pdhead xs)
     , (TestableTerm xs') <- idIfEmpty (pdtail xs)
     ]
     where
@@ -321,10 +321,8 @@ pshrinkDataSum xs
       in TestableTerm $ punsafeCoerce $ pconstrBuiltin # (pfstBuiltin # p - 1) # pto (psndBuiltin # p) 
 
     tS :: TestableTerm (PDataSum defs) -> TestableTerm (PDataSum (def ': defs))
-    tS (TestableTerm ns) =
-      let (TestableTerm p) = pundsum $ TestableTerm $ punsafeCoerce ns
-      in TestableTerm $ punsafeCoerce $ pconstrBuiltin # (pfstBuiltin # p + 1) # pto (psndBuiltin # p)  
-    
+    tS (TestableTerm ns) = TestableTerm $ pmatch ns $ \(PDataSum x) -> pcon $ PDataSum $ SOP.S x
+
 -- | @since 2.2.0
 instance 
   forall (def :: [PLabeledType]) (defs :: [[PLabeledType]]).


### PR DESCRIPTION
Mlabs-Haskell/liqwid-onchain#137

@Pitometsu 

- [x] Generates `PDataRecord`
- [x] Shrinks `PDataRecord`
- [x] Generates `PDataSum`
- [x] Shrinks `PDataSum` (sorta) 
- [ ] Update API instances to use `PDataRecord`
- [ ] See if there's performance difference 