### PR TITLE
TimeDelta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 2.1.4 -- 2022-10-21
+
+### Added
+
+* Newtype wrapper `TimeDelta` for generating bounded changes in `POSIXTime`.
+* Function `withTimeDelta` for CPS-style consumption of `TimeDelta`s in the
+  context of a `Property`.
+
 ## 2.1.3 -- 2022-10-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 ### Added
 
 * Newtype wrapper `TimeDelta` for generating bounded changes in `POSIXTime`.
-* Function `withTimeDelta` for CPS-style consumption of `TimeDelta`s in the
-  context of a `Property`.
+* Function `withTimeDelta` for CPS-style consumption of `TimeDelta`s.
+* Function `timeDeltaProperty` for CPS-style consumption of `TimeDelta`s in a
+  `Property` context.
 
 ## 2.1.3 -- 2022-10-20
 

--- a/plutarch-quickcheck.cabal
+++ b/plutarch-quickcheck.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutarch-quickcheck
-version:            2.1.3
+version:            2.1.4
 synopsis:           Quickcheck for Plutarch.
 description:
   Bridge between QuickCheck and Plutarch. The interfaces provide

--- a/src/Plutarch/Test/QuickCheck/Modifiers.hs
+++ b/src/Plutarch/Test/QuickCheck/Modifiers.hs
@@ -7,6 +7,10 @@ module Plutarch.Test.QuickCheck.Modifiers (
   AdaSymbolPresence (..),
   GenCurrencySymbol (..),
   GenValue (..),
+  TimeDelta,
+
+  -- * Functions
+  withTimeDelta,
 ) where
 
 import Control.Monad (guard)
@@ -16,10 +20,14 @@ import Data.Char (ord)
 import Data.Coerce (Coercible, coerce)
 import Data.Kind (Type)
 import Data.List (nub, sort)
+import Data.Proxy (Proxy (Proxy))
+import Data.Semigroup (Sum (Sum))
 import Data.Word (Word8)
 import GHC.Exts (fromList, fromListN, toList)
+import GHC.TypeNats (KnownNat, Nat, natVal, type (<=))
 import PlutusLedgerApi.V2 (
   CurrencySymbol (CurrencySymbol),
+  POSIXTime (POSIXTime),
   TokenName (TokenName),
   Value (Value),
   fromBuiltin,
@@ -32,6 +40,13 @@ import Test.QuickCheck (
   CoArbitrary (coarbitrary),
   Function (function),
   Gen,
+  Negative (Negative),
+  NonNegative (NonNegative),
+  NonPositive (NonPositive),
+  Positive (Positive),
+  Property,
+  counterexample,
+  property,
   shrinkList,
  )
 import Test.QuickCheck.Function (functionMap)
@@ -292,6 +307,160 @@ instance Function (GenValue adaMod otherMod) where
   {-# INLINEABLE function #-}
   function = functionMap unwrap rewrap
 
+{- | Represents a change in 'POSIXTime'. The @mod@ argument gives the kind of
+ change, represented by a QuickCheck modifier, while the @n@ argument is a
+ closed (inclusive) upper bound on the magnitude of the change.
+
+ For example, @'TimeDelta' 'Positive' 100@ represents a change in 'POSIXTime'
+ from @1@ to @100@ units, while @'TimeDelta' 'NonPositive' 250@ represents a
+ change in 'POSIXTime' from @0@ to @-250@. Modifiers intended to work with
+ this type are:
+
+ - 'Positive'
+ - 'Negative'
+ - 'NonPositive'
+ - 'NonNegative'
+
+ The instances for 'TimeDelta' reflect this decision: while other modifiers
+ could potentially be useful, this ensures that we have safe behaviour and
+ efficient instances.
+
+ Shrinking a 'TimeDelta' will shrink towards zero: more specifically, it will
+ reduce the magnitude of the change.
+
+ To control what 'TimeDelta' you get, the easiest method is a type signature:
+
+ > forAll arbitrary $ \(delta :: TimeDelta NonNegative 100) -> ...
+
+ @since 2.1.4
+-}
+newtype TimeDelta (mod :: Type -> Type) (n :: Nat)
+  = TimeDelta (mod POSIXTime)
+
+-- | @since 2.1.4
+deriving via
+  (mod POSIXTime)
+  instance
+    (forall (a :: Type). (Eq a) => Eq (mod a)) =>
+    Eq (TimeDelta mod n)
+
+-- | @since 2.1.4
+deriving stock instance
+  (forall (a :: Type). (Show a) => Show (mod a)) =>
+  Show (TimeDelta mod n)
+
+{- | Strictly positive deltas are semigroups under addition.
+
+ @since 2.1.4
+-}
+deriving via (Sum Integer) instance Semigroup (TimeDelta Positive n)
+
+{- | Strictly negative deltas are semigroups under addition.
+
+ @since 2.1.4
+-}
+deriving via (Sum Integer) instance Semigroup (TimeDelta Negative n)
+
+{- | Non-negative deltas are semigroups under addition.
+
+ @since 2.1.4
+-}
+deriving via (Sum Integer) instance Semigroup (TimeDelta NonNegative n)
+
+{- | Non-positive deltas are semigroups under addition.
+
+ @since 2.1.4
+-}
+deriving via (Sum Integer) instance Semigroup (TimeDelta NonPositive n)
+
+{- | Non-negative deltas are monoids with the zero delta as the identity.
+
+ @since 2.1.4
+-}
+deriving via (Sum Integer) instance Monoid (TimeDelta NonNegative n)
+
+{- | Non-positive deltas are monoids with the zero delta as the identity.
+
+ @since 2.1.4
+-}
+deriving via (Sum Integer) instance Monoid (TimeDelta NonPositive n)
+
+-- | @since 2.1.4
+instance (KnownNat n, 1 <= n) => Arbitrary (TimeDelta Positive n) where
+  {-# INLINEABLE arbitrary #-}
+  arbitrary = coerce <$> Gen.chooseInteger (1, integerVal @n)
+  {-# INLINEABLE shrink #-}
+  shrink = coerce @(Positive Integer -> [Positive Integer]) shrink
+
+-- | @since 2.1.4
+instance (KnownNat n, 1 <= n) => Arbitrary (TimeDelta Negative n) where
+  {-# INLINEABLE arbitrary #-}
+  arbitrary = coerce <$> Gen.chooseInteger (negate (integerVal @n), negate 1)
+  {-# INLINEABLE shrink #-}
+  shrink = coerce @(Negative Integer -> [Negative Integer]) shrink
+
+-- | @since 2.1.4
+instance (KnownNat n) => Arbitrary (TimeDelta NonPositive n) where
+  {-# INLINEABLE arbitrary #-}
+  arbitrary = coerce <$> Gen.chooseInteger (negate (integerVal @n), 0)
+  {-# INLINEABLE shrink #-}
+  shrink = coerce @(NonPositive Integer -> [NonPositive Integer]) shrink
+
+-- | @since 2.1.4
+instance (KnownNat n) => Arbitrary (TimeDelta NonNegative n) where
+  {-# INLINEABLE arbitrary #-}
+  arbitrary = coerce <$> Gen.chooseInteger (0, integerVal @n)
+  {-# INLINEABLE shrink #-}
+  shrink = coerce @(NonNegative Integer -> [NonNegative Integer]) shrink
+
+-- | @since 2.1.4
+deriving via
+  (mod Integer)
+  instance
+    ( forall (a :: Type) (b :: Type).
+      ( Coercible a b => Coercible (mod a) (mod b)
+      )
+    , CoArbitrary (mod Integer)
+    ) =>
+    CoArbitrary (TimeDelta mod n)
+
+-- | @since 2.1.4
+instance
+  (forall (a :: Type) (b :: Type). Coercible a b => Coercible (mod a) b) =>
+  Function (TimeDelta mod n)
+  where
+  {-# INLINEABLE function #-}
+  function = functionMap (coerce @(TimeDelta mod n) @Integer) coerce
+
+{- | A CPS-style 'Testable' handler for applying a 'TimeDelta' to a 'POSIXTime'.
+ If the application of the delta to the time would produce an impossible
+ result (that is, the resulting time is negative), this will automatically
+ fail the property test with an informative message; otherwise, it will apply
+ the delta, and produce a new 'POSIXTime', which it will pass to the function
+ argument to determine the outcome.
+
+ @since 2.1.4
+-}
+withTimeDelta ::
+  forall (n :: Nat) (mod :: Type -> Type).
+  (Coercible (mod POSIXTime) Integer) =>
+  TimeDelta mod n ->
+  POSIXTime ->
+  (POSIXTime -> Property) ->
+  Property
+withTimeDelta (TimeDelta d) time f = case signum (time + coerce d) of
+  (-1) -> counterexample badConversion . property $ False
+  d' -> f . coerce $ d'
+  where
+    badConversion :: String
+    badConversion =
+      "Applying a TimeDelta would yield an impossible time.\n"
+        <> "Delta: "
+        <> (show . coerce @_ @Integer $ d)
+        <> "\n"
+        <> "Time: "
+        <> show time
+
 -- Helpers
 
 unwrap ::
@@ -384,3 +553,6 @@ coerciveShrink =
   fmap (coerce @(mod Integer) @Integer)
     . shrink
     . coerce @Integer @(mod Integer)
+
+integerVal :: forall (n :: Nat). (KnownNat n) => Integer
+integerVal = fromIntegral . natVal $ Proxy @n


### PR DESCRIPTION
This introduces a modifier `TimeDelta`, designed to generate changes in `POSIXTime`, with a type-safe way to declare the beginning of the bound, the upper limit of the change magnitude, and whether the change is up or down. We also provide a handler for `TimeDelta`s in the context of a `Property`, as well as some helper `Semigroup` and `Monoid` instances for additive combination of `TimeDelta`s.