### PR TITLE
Helpers for Haskell-level property definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 2.1.5 -- 2022-10-27
+
+### Added
+
+* `shouldCrash` and `shouldRun` helpers for Haskell-level property definitions
+  based on `Script` outcomes.
+
 ## 2.1.4 -- 2022-10-21
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -42,14 +42,12 @@ build: requires_nix_shell
 dev: requires_nix_shell
 	cabal v2-build $(GHC_FLAGS) -f development
 
-
 watch: requires_nix_shell
 	while sleep 1;																				\
 	do	                                                  \
 	  find src testlib test plutarch-quickcheck.cabal |   \
 		  entr -cd make $(filter-out $@,$(MAKECMDGOALS));   \
   done
-
 
 test: requires_nix_shell
 	cabal v2-test

--- a/plutarch-quickcheck.cabal
+++ b/plutarch-quickcheck.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutarch-quickcheck
-version:            2.1.4
+version:            2.1.5
 synopsis:           Quickcheck for Plutarch.
 description:
   Bridge between QuickCheck and Plutarch. The interfaces provide


### PR DESCRIPTION
This defines `shouldRun` and `shouldCrash`, which evaluate `Script`s and 'wrap up' their results with some reporting. These are upstreams from `oracle-onchain`, which uses both extensively.