### PR TITLE
Latest liqwid-nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ TAGS
 *.hoo
 *.warn
 haddock/
+
+# Other junk
+clear\ /

--- a/flake.lock
+++ b/flake.lock
@@ -455,11 +455,11 @@
         "nixpkgs-2205": "nixpkgs-2205"
       },
       "locked": {
-        "lastModified": 1660580223,
-        "narHash": "sha256-r1i92rrUjSBdnQZpHLxeCAtVGMHYqKQHm05mzddIte8=",
+        "lastModified": 1666695559,
+        "narHash": "sha256-v8DcNma4hAgLCbPHpsxNYzeMURfbxh20VXfFzUED6bs=",
         "owner": "Liqwid-Labs",
         "repo": "liqwid-nix",
-        "rev": "fa1eeba35b37ac2551a00798dffdf053879699c3",
+        "rev": "7add1f24e9360e96b2bab4a1fc7929d4fa649439",
         "type": "github"
       },
       "original": {
@@ -633,17 +633,16 @@
     },
     "nixpkgs-latest": {
       "locked": {
-        "lastModified": 1659622790,
-        "narHash": "sha256-fYelfx2ScXVprcivGPif+hi9cOZPt3/4wV5rC3AwZDs=",
+        "lastModified": 1667339946,
+        "narHash": "sha256-T3EW8avzTCSJjkc5umfPfmtMWAfx00zC0LKoZ9TG/7I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf63df0364f67848083ff75bc8ac9b7ca7aa5a01",
+        "rev": "741b917812a3fb1ca5db26148b568220d0a5dac4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf63df0364f67848083ff75bc8ac9b7ca7aa5a01",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
       inputs.nixpkgs.follows =
         "plutarch/haskell-nix/nixpkgs-unstable";
     };
-    
+
     liqwid-nix = {
       url = "github:Liqwid-Labs/liqwid-nix";
       inputs.nixpkgs-latest.follows = "nixpkgs-latest";

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.follows = "plutarch/nixpkgs";
-    nixpkgs-latest.url = "github:NixOS/nixpkgs?rev=cf63df0364f67848083ff75bc8ac9b7ca7aa5a01";
+    nixpkgs-latest.url = "github:NixOS/nixpkgs";
 
     # temporary fix for nix versions that have the transitive follows bug
     # see https://github.com/NixOS/nix/issues/6013
@@ -24,8 +24,11 @@
       inputs.nixpkgs.follows =
         "plutarch/haskell-nix/nixpkgs-unstable";
     };
-
-    liqwid-nix.url = "github:Liqwid-Labs/liqwid-nix";
+    
+    liqwid-nix = {
+      url = "github:Liqwid-Labs/liqwid-nix";
+      inputs.nixpkgs-latest.follows = "nixpkgs-latest";
+    };
   };
 
   outputs = inputs@{ liqwid-nix, ... }:

--- a/plutarch-quickcheck.cabal
+++ b/plutarch-quickcheck.cabal
@@ -37,6 +37,7 @@ common common-lang
     , plutarch
 
   default-extensions:
+    NoFieldSelectors
     BangPatterns
     BinaryLiterals
     ConstraintKinds
@@ -64,7 +65,6 @@ common common-lang
     TypeApplications
     TypeFamilies
     TypeOperators
-    NoFieldSelectors
 
   default-language:   Haskell2010
 

--- a/src/Plutarch/Test/QuickCheck.hs
+++ b/src/Plutarch/Test/QuickCheck.hs
@@ -248,10 +248,10 @@ type family CheckReturn (fin :: S -> Type) (p :: S -> Type) :: Constraint where
     , TypeError
         ( 'Text "Return type does not match:"
             ':$$: 'Text "\tExpected \""
-            ':<>: 'ShowType a
-            ':<>: 'Text "\" but given function returns \""
-            ':<>: 'ShowType b
-            ':<>: 'Text "\""
+              ':<>: 'ShowType a
+              ':<>: 'Text "\" but given function returns \""
+              ':<>: 'ShowType b
+              ':<>: 'Text "\""
         )
     )
 
@@ -442,7 +442,9 @@ instance
   where
   haskEquiv h (TestableTerm p) _ =
     counterexample "Comparison by PEq Failed" $
-      property $ plift $ p #== pconstant h
+      property $
+        plift $
+          p #== pconstant h
 
 -- | @since 2.1.0
 instance
@@ -452,7 +454,8 @@ instance
   where
   haskEquiv h (TestableTerm p) _ =
     counterexample "Comparison by PData Failed" $
-      property $ plift (pdata p #== pdata (pconstant h))
+      property $
+        plift (pdata p #== pdata (pconstant h))
 
 -- | @since 2.1.0
 instance

--- a/src/Plutarch/Test/QuickCheck/Internal.hs
+++ b/src/Plutarch/Test/QuickCheck/Internal.hs
@@ -314,10 +314,10 @@ instance PArbitrary a => PArbitrary (PMaybe a) where
       ]
   pshrink (TestableTerm x)
     | plift $ pisJust # x =
-        TestableTerm (pcon PNothing) :
-          [ TestableTerm $ pcon $ PJust a
-          | (TestableTerm a) <- shrink (TestableTerm $ pfromJust # x)
-          ]
+        TestableTerm (pcon PNothing)
+          : [ TestableTerm $ pcon $ PJust a
+            | (TestableTerm a) <- shrink (TestableTerm $ pfromJust # x)
+            ]
     | otherwise = []
 
 instance PCoArbitrary a => PCoArbitrary (PMaybe a) where
@@ -338,10 +338,10 @@ instance (PIsData a, PArbitrary a) => PArbitrary (PMaybeData a) where
       ]
   pshrink (TestableTerm x)
     | plift $ pisDJust # x =
-        pconT (PDNothing pdnil) :
-          [ TestableTerm $ pcon $ PDJust $ pdcons @"_0" # pdata a # pdnil
-          | (TestableTerm a) <- shrink (TestableTerm $ pfromDJust # x)
-          ]
+        pconT (PDNothing pdnil)
+          : [ TestableTerm $ pcon $ PDJust $ pdcons @"_0" # pdata a # pdnil
+            | (TestableTerm a) <- shrink (TestableTerm $ pfromDJust # x)
+            ]
     | otherwise = []
 
 instance (PIsData a, PCoArbitrary a) => PCoArbitrary (PMaybeData a) where
@@ -652,9 +652,13 @@ instance PArbitrary PStakingCredential where
       [ pconT $ PStakingHash $ pdcons @"_0" # pdata cred # pdnil
       , pconT $
           PStakingPtr $
-            pdcons @"_0" # pdata x
-              #$ pdcons @"_1" # pdata y
-              #$ pdcons @"_2" # pdata z # pdnil
+            pdcons @"_0"
+              # pdata x
+              #$ pdcons @"_1"
+              # pdata y
+              #$ pdcons @"_2"
+              # pdata z
+              # pdnil
       ]
 
 -- | @since 2.0.0
@@ -665,8 +669,11 @@ instance PArbitrary PAddress where
     return $
       pconT $
         PAddress $
-          pdcons @"credential" # pdata cred
-            #$ pdcons @"stakingCredential" # pdata scred # pdnil
+          pdcons @"credential"
+            # pdata cred
+            #$ pdcons @"stakingCredential"
+            # pdata scred
+            # pdnil
 
 -- | @since 2.0.0
 instance PArbitrary PCurrencySymbol where
@@ -860,5 +867,6 @@ coArbitraryPListLike ::
 coArbitraryPListLike (TestableTerm x)
   | plift (pnull # x) = variant (0 :: Integer)
   | otherwise =
-      variant (1 :: Integer) . pcoarbitrary (TestableTerm $ phead # x)
+      variant (1 :: Integer)
+        . pcoarbitrary (TestableTerm $ phead # x)
         . pcoarbitrary (TestableTerm $ ptail # x)


### PR DESCRIPTION
This uses the latest `liqwid-nix`. A little fiddling with the flakefile was required to make it behave.