### PR TITLE
export `loudEval`

### DIFF
--- a/plutarch-quickcheck.cabal
+++ b/plutarch-quickcheck.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutarch-quickcheck
-version:            2.1.5
+version:            2.1.6
 synopsis:           Quickcheck for Plutarch.
 description:
   Bridge between QuickCheck and Plutarch. The interfaces provide

--- a/src/Plutarch/Test/QuickCheck.hs
+++ b/src/Plutarch/Test/QuickCheck.hs
@@ -19,6 +19,7 @@ module Plutarch.Test.QuickCheck (
   haskEquiv,
   shrinkPLift,
   arbitraryPLift,
+  loudEval,
   PFun (..),
   pattern PFn,
   TestableTerm (..),

--- a/src/Plutarch/Test/QuickCheck/Helpers.hs
+++ b/src/Plutarch/Test/QuickCheck/Helpers.hs
@@ -5,6 +5,10 @@ module Plutarch.Test.QuickCheck.Helpers (loudEval) where
 import Plutarch (ClosedTerm, Config (..), TracingMode (DoTracing))
 import Plutarch.Evaluate (evalTerm)
 
+{- | Evaluates the 'ClosedTerm' and put evaluation result back into the 'ClosedTerm'.
+
+ @since 2.1.6
+-}
 loudEval :: ClosedTerm p -> ClosedTerm p
 loudEval x =
   case evalTerm (Config {tracingMode = DoTracing}) x of


### PR DESCRIPTION
this is helpful. We can use regular Plutarch value for property testing without performance fall back using `loudEval`. Basically same as doing `applyArguments` but better.