### PR TITLE
Add `fromPPartial` for directly testing functions like `PValidator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 2.1.6 -- 2022-11-10
+
+### Added
+
+* `fromPPartial` allows using a partial function like `PVaildator`. It will
+  expect given function to return `POpaque` and success.
+* `fromFailingPPartial` allows users to test for a Plutarch partial function
+  that will fail. Unlike QC `expectFailure`, this will *not* abort after first
+  encounter of the failure.
+* `pexpectFailure` changes regular unplam-ed Plutarch function into expecting
+  failure. It does samething as `fromFailingPPartial` but it can be used on
+  return type other than `POpaque`.
+* `FailingTestableTerm` is a wrapper around regular `TestableTerm` but indicates
+  a case is expecting a failure.
+
 ## 2.1.5 -- 2022-10-27
 
 ### Added

--- a/plutarch-quickcheck.cabal
+++ b/plutarch-quickcheck.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutarch-quickcheck
-version:            2.1.5
+version:            2.1.6
 synopsis:           Quickcheck for Plutarch.
 description:
   Bridge between QuickCheck and Plutarch. The interfaces provide

--- a/plutarch-quickcheck.cabal
+++ b/plutarch-quickcheck.cabal
@@ -134,6 +134,15 @@ test-suite zip-test
   main-is:        Main.hs
   hs-source-dirs: sample/zip-test
 
+test-suite validator-test
+  import:
+    common-tests,
+    common-lang
+
+  type:           exitcode-stdio-1.0
+  main-is:        Main.hs
+  hs-source-dirs: sample/validator-test
+
 test-suite instances
   import:
     common-tests,

--- a/sample/reverse-test/Main.hs
+++ b/sample/reverse-test/Main.hs
@@ -75,13 +75,17 @@ hreverse [] = []
 -- `haskEquiv'` will construct a property using `Arbitrary` instance.
 propCorrect :: Property
 propCorrect =
-  haskEquiv' @( 'OnPEq) @( 'ByComplete)
+  haskEquiv'
+    @( 'OnPEq)
+    @( 'ByComplete)
     hreverse
     (preverseCorrect @PBuiltinList @PInteger)
 
 propWrong :: Property
 propWrong =
-  haskEquiv' @( 'OnPEq) @( 'ByComplete)
+  haskEquiv'
+    @( 'OnPEq)
+    @( 'ByComplete)
     hreverse
     (preverseWrong @PBuiltinList @PInteger)
 
@@ -91,7 +95,9 @@ propWrong =
 -- from `Generics.SOP`. (hint: it's using `NP`)
 propCustom :: Property
 propCustom =
-  haskEquiv @( 'OnPEq) @( 'ByComplete)
+  haskEquiv
+    @( 'OnPEq)
+    @( 'ByComplete)
     hreverse
     (TestableTerm preverseCorrect)
     (genList :* Nil)

--- a/sample/validator-test/Main.hs
+++ b/sample/validator-test/Main.hs
@@ -53,6 +53,18 @@ valProp =
         # pforgetData (pdata x)
         # pforgetData (pdata x)
 
+valPropFail :: Property
+valPropFail =
+  forAll (pconstantT <$> chooseInteger (15, 4000)) $
+    fromFailingPPartial valScript
+  where
+    valScript :: forall (s :: S). Term s (PInteger :--> POpaque)
+    valScript = plam $ \x ->
+      myValidator
+        # 5
+        # pforgetData (pdata x)
+        # pforgetData (pdata x)
+
 main :: IO ()
 main = do
   -- This will fix some problems regarding text encoding.
@@ -61,6 +73,7 @@ main = do
     testGroup
       ""
       [ testProperty "Validator Property" valProp
+      , testProperty "Validator Property - should fail" valPropFail
       ]
   where
     -- 100 tests is way too small for a property test to search for a counterexample,

--- a/sample/validator-test/Main.hs
+++ b/sample/validator-test/Main.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-unused-imports #-}
-{-# OPTIONS_GHC -Wno-unused-matches #-}
-{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 {- | Module: Main
  Copyright: (C) Liqwid Labs 2022
@@ -15,13 +12,36 @@
 module Main (main) where
 
 import GHC.IO.Encoding (setLocaleEncoding, utf8)
-import Plutarch.Builtin
-import Plutarch.Prelude
-import Plutarch.Test.QuickCheck
-import Test.QuickCheck
-import Test.Tasty
-import Test.Tasty.ExpectedFailure
-import Test.Tasty.QuickCheck
+import Plutarch.Builtin (pforgetData)
+import Plutarch.Prelude (
+  PData,
+  PInteger,
+  POpaque,
+  S,
+  Term,
+  pconstant,
+  pdata,
+  pfromData,
+  pif,
+  plam,
+  popaque,
+  ptraceError,
+  ptryFrom,
+  tcont,
+  unTermCont,
+  (#),
+  (#<),
+  (:-->),
+ )
+import Plutarch.Test.QuickCheck (fromFailingPPartial, fromPPartial, pconstantT)
+import Test.Tasty (adjustOption, defaultMain, testGroup)
+import Test.Tasty.QuickCheck (
+  Property,
+  QuickCheckTests,
+  chooseInteger,
+  forAll,
+  testProperty,
+ )
 
 -- This is an example pseudo validator that will pass when the sum of parameter
 -- and the datum is less than 20.
@@ -71,7 +91,7 @@ main = do
   setLocaleEncoding utf8
   defaultMain . adjustOption go $
     testGroup
-      ""
+      "validator tests"
       [ testProperty "Validator Property" valProp
       , testProperty "Validator Property - should fail" valPropFail
       ]

--- a/sample/validator-test/Main.hs
+++ b/sample/validator-test/Main.hs
@@ -73,6 +73,12 @@ valProp =
         # pforgetData (pdata x)
         # pforgetData (pdata x)
 
+-- When 'valProp' checks for values that should pass the validator, this
+-- property checks if validator fails when given incorrect values.
+-- This is somewhat of a negative case for the validator.
+--
+-- Unlike 'expectFailure' given by the QuickCheck, using 'fromFailingPPartial'
+-- will not abort the test after getting a failure.
 valPropFail :: Property
 valPropFail =
   forAll (pconstantT <$> chooseInteger (15, 4000)) $

--- a/sample/validator-test/Main.hs
+++ b/sample/validator-test/Main.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
+{- | Module: Main
+ Copyright: (C) Liqwid Labs 2022
+ License: Apache 2.0
+ Portability: GHC only
+ Stability: Experimental
+ Example of @plutarch-quickcheck@ tests. These are meant to be read as source
+ code.
+-}
+module Main (main) where
+
+import GHC.IO.Encoding (setLocaleEncoding, utf8)
+import Plutarch.Builtin
+import Plutarch.Prelude
+import Plutarch.Test.QuickCheck
+import Test.QuickCheck
+import Test.Tasty
+import Test.Tasty.ExpectedFailure
+import Test.Tasty.QuickCheck
+
+-- This is an example pseudo validator that will pass when the sum of parameter
+-- and the datum is less than 20.
+-- Example doesn't use actual 'PValidator' because 'PScriptContext' is hard to
+-- generate without PCB(Plutarch Context Builder).
+myValidator ::
+  forall (s :: S).
+  Term s (PInteger :--> PData :--> PData :--> POpaque)
+myValidator = plam $ \param dat _red -> unTermCont $ do
+  (dat', _) <- tcont $ ptryFrom dat
+
+  pure $
+    pif
+      (pfromData dat' + param #< 20)
+      (popaque $ pconstant ())
+      (ptraceError "param + datum is larger than 20")
+
+-- Property test. This uses 'fromPPartial'; it will fail when the validator
+-- fails and will pass when validator succeed.
+valProp :: Property
+valProp =
+  forAll (pconstantT <$> chooseInteger (0, 14)) $
+    fromPPartial valScript
+  where
+    valScript :: forall (s :: S). Term s (PInteger :--> POpaque)
+    valScript = plam $ \x ->
+      myValidator
+        # 5
+        # pforgetData (pdata x)
+        # pforgetData (pdata x)
+
+main :: IO ()
+main = do
+  -- This will fix some problems regarding text encoding.
+  setLocaleEncoding utf8
+  defaultMain . adjustOption go $
+    testGroup
+      ""
+      [ testProperty "Validator Property" valProp
+      ]
+  where
+    -- 100 tests is way too small for a property test to search for a counterexample,
+    -- it is recommanded to use at least 10,000. However, more is better.
+    go :: QuickCheckTests -> QuickCheckTests
+    go = max 10_000

--- a/src/Plutarch/Test/QuickCheck.hs
+++ b/src/Plutarch/Test/QuickCheck.hs
@@ -15,6 +15,7 @@ module Plutarch.Test.QuickCheck (
   punlam',
   punlam,
   fromPFun,
+  fromPPartial,
   haskEquiv',
   haskEquiv,
   shrinkPLift,
@@ -49,6 +50,7 @@ import Plutarch.Prelude (
   PInteger,
   PIsData,
   PLift,
+  POpaque,
   POrd,
   PPartialOrd,
   PlutusType,
@@ -324,6 +326,20 @@ fromPFun ::
   ClosedTerm p ->
   PLamWrapped (PUnLamHask PBool p)
 fromPFun pf = pwrapLam $ punlam @PBool pf
+
+{- | Same as 'fromPFun' but it expects 'POpaque' as the return type. It is
+     helpful testing partial functions like 'PValidator'.
+
+ @since 2.1.6
+-}
+fromPPartial ::
+  forall (p :: S -> Type).
+  ( PUnLam POpaque p
+  , PWrapLam (PUnLamHask POpaque p)
+  ) =>
+  ClosedTerm p ->
+  PLamWrapped (PUnLamHask POpaque p)
+fromPPartial pf = pwrapLam $ punlam @POpaque pf
 
 {- | Ways an Plutarch terms can be compared.
      @OnPEq@ uses Plutarch `PEq` instance to compare give terms. This

--- a/src/Plutarch/Test/QuickCheck.hs
+++ b/src/Plutarch/Test/QuickCheck.hs
@@ -398,7 +398,7 @@ fromFailingPPartial pf = pexpectFailure $ pwrapLam $ punlam @POpaque pf
 
 {- | Ways an Plutarch terms can be compared.
      @OnPEq@ uses Plutarch `PEq` instance to compare give terms. This
-     means to terms with different UPLC representations can be
+     means two terms with different UPLC representations can be
      considered equal when `PEq` instance defines so.
      @OnUPLC@ uses compiled and evaluated raw UPLC to compare two
      terms. It is useful comparing Terms that forgot their types--

--- a/src/Plutarch/Test/QuickCheck/Internal.hs
+++ b/src/Plutarch/Test/QuickCheck/Internal.hs
@@ -156,7 +156,7 @@ instance Testable (TestableTerm POpaque) where
         case evalScriptHuge script of
           (Left err, _, trace) ->
             counterexample
-              ( "Script failed to run:\n"
+              ( "Script evaluated with an error:\n"
                   <> show err
                   <> "\nTrace:\n"
                   <> show trace


### PR DESCRIPTION
With `fromPPartial`, we can test the validators directly without manually compiling scripts and evaluating. There is an example provided along.

Basically, this will take care of all pre-evaluation shenanigans! 