### PR TITLE
Correlate PArbitrary with Arbitrary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 2.1.6 -- 2022-10-27
+
+### Modified
+
+* `PArbitrary` for `PPOSIXTime` now generates only non-negative values, in
+  agreement with the `POSIXTime` instance in `Instances`.
+
 ## 2.1.5 -- 2022-10-27
 
 ### Added

--- a/plutarch-quickcheck.cabal
+++ b/plutarch-quickcheck.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutarch-quickcheck
-version:            2.1.5
+version:            2.1.6
 synopsis:           Quickcheck for Plutarch.
 description:
   Bridge between QuickCheck and Plutarch. The interfaces provide

--- a/src/Plutarch/Test/QuickCheck/Internal.hs
+++ b/src/Plutarch/Test/QuickCheck/Internal.hs
@@ -727,13 +727,12 @@ instance PArbitrary PTxOutRef where
     TestableTerm id' <- parbitrary
     TestableTerm idx <- abs <$> parbitrary
     pure . pconT $ PTxOutRef $ pdcons # pdata id' #$ pdcons # pdata idx # pdnil
-  pshrink ref = do
-    let (TestableTerm ref') = ref
-    TestableTerm idx' <- pshrink $ TestableTerm $ pfield @"idx" # ref'
+  pshrink (TestableTerm ref) = do
+    TestableTerm idx' <- pshrink $ TestableTerm $ pfield @"idx" # ref
     pure . pconT $
       PTxOutRef $
         pdcons
-          # (pfield @"id" # ref')
+          # (pfield @"id" # ref)
           #$ pdcons
           # idx'
           # pdnil

--- a/src/Plutarch/Test/QuickCheck/Internal.hs
+++ b/src/Plutarch/Test/QuickCheck/Internal.hs
@@ -68,6 +68,7 @@ import Plutarch.Extra.Maybe (
  )
 import Plutarch.Lift (PUnsafeLiftDecl (PLifted), plift)
 import Plutarch.Maybe (pfromJust)
+import Plutarch.Num (pabs)
 import Plutarch.Positive (PPositive, ptryPositive)
 import Plutarch.Prelude (
   PAsData,
@@ -547,9 +548,8 @@ instance
 -- | @since 2.0.0
 instance PArbitrary PPOSIXTime where
   parbitrary = do
-    (TestableTerm x) <- parbitrary
-    return $ pconT $ PPOSIXTime x
-
+    TestableTerm x <- parbitrary
+    return . pconT $ PPOSIXTime $ pabs # x
   pshrink = fmap (\(TestableTerm x) -> pconT $ PPOSIXTime x) . shrink . unTime
     where
       unTime = flip pmatchT $ \(PPOSIXTime a) -> a


### PR DESCRIPTION
This ensures that our `PArbitrary` instances for ledger-related Plutarch types correlate with their Haskell equivalents. We also add several.

Key things not done:

* `PDatum` has no instance, as this would require an instance for `PData`, which is tricky to do without lifting everywhere. It's possible, but requires heavy use of builtins, which is outside of our scope.
* `PCurrencySymbol` and `PValue`, as these both use helper newtypes. This again can be done, but would take a long time to get right.